### PR TITLE
No-op on delete or restore on previously scheduled documents.

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/SoftDelete/SoftDeleteManager.php
+++ b/lib/Doctrine/ODM/MongoDB/SoftDelete/SoftDeleteManager.php
@@ -220,13 +220,12 @@ class SoftDeleteManager
      * Schedules a SoftDeleteable document instance for deletion on next flush.
      *
      * @param SoftDeleteable $document
-     * @throws InvalidArgumentException
      */
     public function delete(SoftDeleteable $document)
     {
         $oid = spl_object_hash($document);
         if (isset($this->documentDeletes[$oid])) {
-            throw new \InvalidArgumentException('Document is already scheduled for delete.');
+            return;
         }
 
         // If scheduled for restore then remove it
@@ -243,13 +242,12 @@ class SoftDeleteManager
      * Schedules a SoftDeleteable document instance for restoration on next flush.
      *
      * @param SoftDeleteable $document
-     * @throws InvalidArgumentException
      */
     public function restore(SoftDeleteable $document)
     {
         $oid = spl_object_hash($document);
         if (isset($this->documentRestores[$oid])) {
-            throw new \InvalidArgumentException('Document is already scheduled for restore.');
+            return;
         }
 
         // If scheduled for delete then remove it

--- a/lib/Doctrine/ODM/MongoDB/SoftDelete/SoftDeleteManager.php
+++ b/lib/Doctrine/ODM/MongoDB/SoftDelete/SoftDeleteManager.php
@@ -27,7 +27,7 @@ use MongoDate;
 
 /**
  * The SoftDeleteManager class is responsible for managing the deleted state of a SoftDeleteable instance.
- * 
+ *
  * @license     http://www.opensource.org/licenses/lgpl-license.php LGPL
  * @link        www.doctrine-project.com
  * @since       1.0

--- a/tests/Doctrine/ODM/MongoDB/SoftDelete/Tests/SoftDeleteManagerTest.php
+++ b/tests/Doctrine/ODM/MongoDB/SoftDelete/Tests/SoftDeleteManagerTest.php
@@ -10,47 +10,43 @@ use PHPUnit_Framework_TestCase;
 
 class SoftDeleteManagerTest extends PHPUnit_Framework_TestCase
 {
+    private $dm;
+    private $configuration;
+    private $eventManager;
+    private $softDeleteable;
+    private $sdm;
+
+    protected function setUp()
+    {
+        $this->dm = $this->getMockDocumentManager();
+        $this->configuration = $this->getMockConfiguration();
+        $this->eventManager = $this->getMockEventManager();
+        $this->softDeleteable = $this->getMockSoftDeletable();
+        $this->sdm = new SoftDeleteManager($this->dm, $this->configuration, $this->eventManager);
+    }
+
     public function testConstructor()
     {
-        $dm = $this->getMockDocumentManager();
-        $configuration = $this->getMockConfiguration();
-        $eventManager = $this->getMockEventManager();
-        $uow = $this->getTestSoftDeleteManager($dm, $configuration, $eventManager);
-        $this->assertSame($dm, $uow->getDocumentManager());
+        $this->assertSame($this->dm, $this->sdm->getDocumentManager());
+        $this->assertSame($this->configuration, $this->sdm->getConfiguration());
+        $this->assertSame($this->eventManager, $this->sdm->getEventManager());
     }
 
     public function testDelete()
     {
-        $mockSoftDeleteable = $this->getMockSoftDeletable();
-        $dm = $this->getMockDocumentManager();
-        $configuration = $this->getMockConfiguration();
-        $eventManager = $this->getMockEventManager();
-        $uow = $this->getTestSoftDeleteManager($dm, $configuration, $eventManager);
-        $uow->delete($mockSoftDeleteable);
-        $this->assertTrue($uow->isScheduledForDelete($mockSoftDeleteable));
+        $this->sdm->delete($this->softDeleteable);
+        $this->assertTrue($this->sdm->isScheduledForDelete($this->softDeleteable));
     }
 
     public function testRestore()
     {
-        $mockSoftDeleteable = $this->getMockSoftDeletable();
-        $dm = $this->getMockDocumentManager();
-        $configuration = $this->getMockConfiguration();
-        $eventManager = $this->getMockEventManager();
-        $uow = $this->getTestSoftDeleteManager($dm, $configuration, $eventManager);
-        $uow->restore($mockSoftDeleteable);
-        $this->assertTrue($uow->isScheduledForRestore($mockSoftDeleteable));
-    }
-
-    private function getTestSoftDeleteManager(DocumentManager $dm, Configuration $configuration, EventManager $eventManager)
-    {
-        return new SoftDeleteManager($dm, $configuration, $eventManager);
+        $this->sdm->restore($this->softDeleteable);
+        $this->assertTrue($this->sdm->isScheduledForRestore($this->softDeleteable));
     }
 
     private function getMockConfiguration()
     {
-        return $this->getMockBuilder('Doctrine\ODM\MongoDB\SoftDelete\Configuration')
-            ->disableOriginalConstructor()
-            ->getMock();
+        return $this->getMock('Doctrine\ODM\MongoDB\SoftDelete\Configuration');
     }
 
     private function getMockDocumentManager()
@@ -62,9 +58,7 @@ class SoftDeleteManagerTest extends PHPUnit_Framework_TestCase
 
     private function getMockSoftDeletable()
     {
-        return $this->getMockBuilder('Doctrine\ODM\MongoDB\SoftDelete\SoftDeleteable')
-            ->disableOriginalConstructor()
-            ->getMock();
+        return $this->getMock('Doctrine\ODM\MongoDB\SoftDelete\SoftDeleteable');
     }
 
     private function getMockEventManager()

--- a/tests/Doctrine/ODM/MongoDB/SoftDelete/Tests/SoftDeleteManagerTest.php
+++ b/tests/Doctrine/ODM/MongoDB/SoftDelete/Tests/SoftDeleteManagerTest.php
@@ -36,12 +36,20 @@ class SoftDeleteManagerTest extends PHPUnit_Framework_TestCase
     {
         $this->sdm->delete($this->softDeleteable);
         $this->assertTrue($this->sdm->isScheduledForDelete($this->softDeleteable));
+
+        $deletes = $this->sdm->getDocumentDeletes();
+        $this->sdm->delete($this->softDeleteable);
+        $this->assertEquals($deletes, $this->sdm->getDocumentDeletes(), 'Delete of already scheduled document does nothing');
     }
 
     public function testRestore()
     {
         $this->sdm->restore($this->softDeleteable);
         $this->assertTrue($this->sdm->isScheduledForRestore($this->softDeleteable));
+
+        $restores = $this->sdm->getDocumentRestores();
+        $this->sdm->restore($this->softDeleteable);
+        $this->assertEquals($restores, $this->sdm->getDocumentRestores(), 'Restore of already scheduled document does nothing');
     }
 
     private function getMockConfiguration()


### PR DESCRIPTION
Talked about in #5. No need to throw an exception here. If you persist the same object twice in the manager, it acts the same way. Might as well keep it consistent.

Also cleaned up `SoftDeleteManagerTest` a bit while I was in there and added more coverage for the constructor. Just made the actual tests a little more succinct.
