### PR TITLE
Fix issue whereby deleteBy and restoreBy are not being flushed

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/SoftDelete/SoftDeleteManager.php
+++ b/lib/Doctrine/ODM/MongoDB/SoftDelete/SoftDeleteManager.php
@@ -266,12 +266,12 @@ class SoftDeleteManager
     public function flush()
     {
         // document deletes
-        if ($this->documentDeletes) {
+        if ($this->documentDeletes || $this->deleteBy) {
             $this->executeDeletes();
         }
 
         // document restores
-        if ($this->documentRestores) {
+        if ($this->documentRestores || $this->restoreBy) {
             $this->executeRestores();
         }
     }


### PR DESCRIPTION
Flush only runs executeDeletes and executeRestores when there are values stored in documentDeletes or documentRestores. However when using exclusively the deleteBy or restoreBy methods the documentDeletes/documentRestores parameters remain empty and therefor the flush never executes the deleteBy/restoreBy criteria.

I have added the addition OR condition to ensure that the execute\* methods are called when the document\* parameters are empty but the deleteBy/restoreBy parameters hold values.
